### PR TITLE
Arreglo de la condición para filtrar los contactos

### DIFF
--- a/part2/phonebook/src/components/FilterShown.jsx
+++ b/part2/phonebook/src/components/FilterShown.jsx
@@ -16,7 +16,7 @@ export function FilterShown({contacts}) {
 			</div>
 
 			{contacts.map((value) => {
-				if (value.name.toLowerCase().includes(filter)) {		
+				if (value.name.toLowerCase().includes(filter) && filter !== "") {		
 					return <h3 key={value.id}>{value.name}, {value.number} </h3>;
 				}
 			})}


### PR DESCRIPTION
Se agrego un && a la condición que filtraba los contactos para no mostrarlos a todos cuando el input filter estuviera vació