### PR TITLE
3.2: backend de la agenda telefónica, paso 2

### DIFF
--- a/part3/phonebook/index.js
+++ b/part3/phonebook/index.js
@@ -29,7 +29,14 @@ app.get("/api/persons", (request, response) => {
     response.json(persons)
 })
 
+app.get("/info", (request, response) => {
+  const cabtidadContactos = persons.length;
+  
+  response.send(`<p>La agenda tiene información de ${cabtidadContactos} personas</p> <p>${Date()}</p>`)
+})
+
+
 const PORT = 3001
 app.listen(PORT, () => {
-    console.log("el sever esta en el puerto", PORT)
+    console.log("el sever esta en el puerto ", PORT)
 })


### PR DESCRIPTION
Implemente una página en la dirección http://localhost:3001/info.
La página tiene que mostrar la hora en que se recibió la solicitud y cuántas entradas hay en la agenda telefónica en el momento de procesar la solicitud.